### PR TITLE
Update resize.js

### DIFF
--- a/addon/services/resize.js
+++ b/addon/services/resize.js
@@ -23,8 +23,8 @@ export default Base.extend(Evented, {
     this._setDefaults();
     this._onResizeHandler = (evt) => {
       this._fireResizeNotification(evt);
-      let debounce = debounce(this, this._fireDebouncedResizeNotification, evt, this.get('debounceTimeout'));
-      this._scheduledDebounce = debounce;
+      let scheduledDebounce = debounce(this, this._fireDebouncedResizeNotification, evt, this.get('debounceTimeout'));
+      this._scheduledDebounce = scheduledDebounce;
     };
     this._installResizeListener();
   },


### PR DESCRIPTION
When trying out this branch got a number of errors:
```
Uncaught TypeError: debounce is not a function
    at exports.default.Base.extend.init._onResizeHandler
```

Likely some naming collision causing it, fixed by renaming the local variable.